### PR TITLE
Only copy the binary in the final docker image

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -16,6 +16,6 @@ FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 # Copy image from previous stage
-COPY --from=builder gallery /app
+COPY --from=builder /gallery/gallery /app/
 
 CMD ["/app/gallery"]

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -18,6 +18,6 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 # Copy binary from previous stage
 COPY --from=builder /gallery/gallery /app/
 # Copy templates
-COPY --from=builder /gallery/ui /app/
+COPY --from=builder /gallery/ui /app/ui/
 
 CMD ["/app/gallery"]

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -15,7 +15,7 @@ FROM scratch
 # Certificates. Assume image is up to date. On Alpine could RUN apk --no-cache add ca-certificates
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
-# Copy image from previous stage
+# Copy binary from previous stage
 COPY --from=builder /gallery/gallery /app/
 
 CMD ["/app/gallery"]

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -17,5 +17,7 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 # Copy binary from previous stage
 COPY --from=builder /gallery/gallery /app/
+# Copy templates
+COPY --from=builder /gallery/ui /app/
 
 CMD ["/app/gallery"]


### PR DESCRIPTION
The previous version ships an image containing the binary and the source code (you can easily prove this in different ways). If that is not the original intention then this change should fix it and only copy the compiled binary.